### PR TITLE
Check task instances on run-once with wait for completion.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+-   `run-once` with `wait-for-completion` checks for task instance failure as well
 
 ## [0.1.1] - 2021-03-19
 

--- a/kedro_airflow_k8s/airflow.py
+++ b/kedro_airflow_k8s/airflow.py
@@ -126,10 +126,19 @@ class AirflowClient:
         return res.json()["dag_run_id"]
 
     @staticmethod
-    def _check_state(response):
+    def _check_task_instances_state(response) -> Optional[str]:
+        if response.status_code != 200:
+            return None
+        instances = response.json()["task_instances"]
+        failed_instances = [i for i in instances if i["state"] == "failed"]
+        return "failed" if len(failed_instances) > 0 else None
+
+    @staticmethod
+    def _check_dag_run_state(response) -> Optional[str]:
         if response.status_code != 200:
             return "unknown"
         state = response.json()["state"]
+
         return state if state != "running" else None
 
     def _wait_for_dag_run_completion(
@@ -146,9 +155,18 @@ class AirflowClient:
                 headers={"Content-Type": "application/json"},
                 verify=AirflowClient.VERIFY,
             )
-            last_state = AirflowClient._check_state(res)
-            if last_state:
-                break
+            last_state = AirflowClient._check_dag_run_state(res)
+            if last_state == "success":
+                res = session.get(
+                    f"{self.rest_api_url}/dags/{dag_id}/dagRuns/{dag_run_id}/"
+                    f"taskInstances"
+                )
+                return (
+                    AirflowClient._check_task_instances_state(res) or "success"
+                )
+
+            if last_state is not None:
+                return last_state
 
             sleep(self.retry_interval)
         return last_state

--- a/kedro_airflow_k8s/airflow_dag_template.j2
+++ b/kedro_airflow_k8s/airflow_dag_template.j2
@@ -118,7 +118,7 @@ with DAG(
                 - name: MLFLOW_RUN_ID
                   value: {% raw %}{{ task_instance.xcom_pull(key="mlflow_run_id") }}{% endraw %}
               args:
-                - 'kedro'
+                - 'kedroa'
                 - 'run'
                 - '-e' 
                 - '{{ env }}'

--- a/kedro_airflow_k8s/airflow_dag_template.j2
+++ b/kedro_airflow_k8s/airflow_dag_template.j2
@@ -118,7 +118,7 @@ with DAG(
                 - name: MLFLOW_RUN_ID
                   value: {% raw %}{{ task_instance.xcom_pull(key="mlflow_run_id") }}{% endraw %}
               args:
-                - 'kedroa'
+                - 'kedro'
                 - 'run'
                 - '-e' 
                 - '{{ env }}'


### PR DESCRIPTION
DAG run state may be successful, even if task instances are failing (f.e. for trigger run 'all_done').

Closing #32 