### PR TITLE
Allow AWS S3 usage for upload of DAGs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 -   Resources configuration added that allows describing cpu and memory resources required in k8s by pods 
+-   Support of S3 as DAG destination
 
 ## [0.2.0] - 2021-04-01
 

--- a/docs/source/03_getting_started/01_quickstart.md
+++ b/docs/source/03_getting_started/01_quickstart.md
@@ -180,3 +180,6 @@ kedro airflow-k8s -e pipelines upload-pipeline -o ${AIRFLOW_DAG_HOME}
 
 in order to get DAG copied directly to Airflow DAG folder. Google Cloud Storage locations are also support with `gcs://`
 or `gs://` prefix in the parameter (this requires plugin to be installed with `pip install kedro-airflow-k8s[gcp]`).
+
+In order to use AWS S3 as storage, prefix output with `s3://` (this requires plugin to be installed with 
+`pip install kedro-airflow-k8s[aws]`).

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ EXTRA_REQUIRE = {
     "gcp": [
         "gcsfs>=0.6.2, <0.7.0",
     ],
+    "aws": ["s3fs>=0.6.0"],
     "mlflow": ["kedro-mlflow==0.4.1"],
 }
 


### PR DESCRIPTION
Simplify usage in AWS environment and open access for S3 as upload storage.

Resolves #46 

---
Keep in mind: 
- [x] Documentation updates
- [x] [Changelog](CHANGELOG.md) updates 
