### PR TITLE
startup_timeout added to run_config.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 -   Resources configuration added that allows describing cpu and memory resources required in k8s by pods
 -   Shared persistent volume can be made optional
+-   Pod startup timeout is configurable, with default to 600 seconds
 
 ## [0.2.0] - 2021-04-01
 

--- a/docs/source/02_installation/02_configuration.md
+++ b/docs/source/02_installation/02_configuration.md
@@ -18,6 +18,9 @@ run_config:
     # Pull policy to be used for the steps. Use Always if you push the images
     # on the same tag, or Never if you use only local images
     image_pull_policy: IfNotPresent
+    
+    # Pod startup timeout in seconds - if timeout passes the pipeline fails, default to 600 
+    startup_time: 600
 
     # Namespace for Airflow pods to be created
     namespace: airflow

--- a/kedro_airflow_k8s/airflow_dag_template.j2
+++ b/kedro_airflow_k8s/airflow_dag_template.j2
@@ -99,7 +99,7 @@ with DAG(
     data_volume_init = KubernetesPodOperator(
         task_id="data_volume_init",
         is_delete_operator_pod=True,
-        startup_timeout_seconds=600,
+        startup_timeout_seconds={{ config.run_config.startup_timeout }},
         pod_template_file=data_volume_init_definition
     )
         {% endif %}
@@ -167,7 +167,7 @@ with DAG(
     tasks["{{ node.name | slugify }}"] = KubernetesPodOperator(
         task_id="{{ node.name | slugify }}",
         is_delete_operator_pod=True,
-        startup_timeout_seconds=600,
+        startup_timeout_seconds={{ config.run_config.startup_timeout }},
         pod_template_file=pod_definition
     )
     {% endfor %}

--- a/kedro_airflow_k8s/airflow_dag_template.j2
+++ b/kedro_airflow_k8s/airflow_dag_template.j2
@@ -26,7 +26,7 @@ with DAG(
     tags=['commit_sha:{{ git_info.commit_sha }}',
             'generated_with_kedro_airflow_k8s:{{ kedro_airflow_k8s_version }}',
             'experiment_name:'+EXPERIMENT_NAME],
-    params={"example_key": "example_value"},
+    params={},
 ) as dag:
 
     pvc_name = '{{ project_name | safe | slugify }}.{% raw %}{{ ts_nodash | lower  }}{% endraw %}'

--- a/kedro_airflow_k8s/config.py
+++ b/kedro_airflow_k8s/config.py
@@ -19,6 +19,9 @@ run_config:
     # on the same tag, or Never if you use only local images
     image_pull_policy: IfNotPresent
 
+    # Pod startup timeout in seconds
+    startup_timeout: 600
+
     # Namespace for Airflow pods to be created
     namespace: airflow
 
@@ -158,6 +161,10 @@ class RunConfig(Config):
     @property
     def image_pull_policy(self):
         return self._get_or_default("image_pull_policy", "IfNotPresent")
+
+    @property
+    def startup_timeout(self):
+        return self._get_or_default("startup_timeout", 600)
 
     @property
     def namespace(self):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -64,6 +64,7 @@ class TestPluginCLI:
                     "namespace": "test_ns",
                     "experiment_name": "kedro_airflow_k8s",
                     "cron_expression": None,
+                    "startup_timeout": 120,
                     "volume": {
                         "access_modes": ["ReadWriteMany"],
                         "size": "3Gi",
@@ -119,6 +120,7 @@ class TestPluginCLI:
         assert 'cpu: "4"' in dag_content
         assert 'cpu: "16"' in dag_content
         assert "target/k8s.io: mammoth" in dag_content
+        assert "startup_timeout_seconds=120" in dag_content
 
     def test_upload_pipeline(self, context_helper):
         config = dict(context_helper=context_helper)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -16,6 +16,7 @@ run_config:
     run_name: test-experiment-branch
     cron_expression: "@hourly"
     description: "test pipeline"
+    startup_timeout: 120
     volume:
         storageclass: kms
         size: 3Gi
@@ -48,6 +49,7 @@ class TestPluginConfig(unittest.TestCase):
         assert cfg.run_config
         assert cfg.run_config.image == "test.image:1234"
         assert cfg.run_config.image_pull_policy == "Always"
+        assert cfg.run_config.startup_timeout == 120
         assert cfg.run_config.namespace == "airflow-test"
         assert cfg.run_config.experiment_name == "test-experiment"
         assert cfg.run_config.run_name == "test-experiment-branch"
@@ -84,6 +86,7 @@ class TestPluginConfig(unittest.TestCase):
 
         assert cfg.run_config
         assert cfg.run_config.image_pull_policy == "IfNotPresent"
+        assert cfg.run_config.startup_timeout == 600
         assert cfg.run_config.cron_expression == "@daily"
         assert cfg.run_config.description is None
 


### PR DESCRIPTION
As in title, pod startup timeout is now configurable with default to 600 seconds.

Resolves #51 

---
Keep in mind: 
- [x] Documentation updates
- [x] [Changelog](CHANGELOG.md) updates 
