### PR TITLE
Add docker image to mlflow run

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -31,7 +31,7 @@ jobs:
         pip install .[mlflow,tests]
         pip freeze
         pipdeptree
-        pre-commit run --all-files | true
+        pre-commit run --all-files || true
         git diff 
 
     - name: Test with tox

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -31,8 +31,7 @@ jobs:
         pip install .[mlflow,tests]
         pip freeze
         pipdeptree
-        pre-commit run --all-files || true
-        git diff 
+        pre-commit run --all-files
 
     - name: Test with tox
       run: |

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -31,7 +31,8 @@ jobs:
         pip install .[mlflow,tests]
         pip freeze
         pipdeptree
-        pre-commit run --all-files
+        pre-commit run --all-files | true
+        git diff 
 
     - name: Test with tox
       run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+-   Docker image added as a Mlflow run parameter (to support kedro inference pipeline)
+
 ## [0.5.0] - 2021-04-30
 
 -   External dependencies can be added as optionals in configuration

--- a/kedro_airflow_k8s/airflow_dag_template.j2
+++ b/kedro_airflow_k8s/airflow_dag_template.j2
@@ -41,7 +41,8 @@ with DAG(
     {% if mlflow_url %}
     start_mlflow_run = StartMLflowExperimentOperator(
         experiment_name=EXPERIMENT_NAME,
-        mlflow_url='{{ mlflow_url }}'
+        mlflow_url='{{ mlflow_url }}',
+        image="{{ image }}",
     )
     {% endif %}
 

--- a/kedro_airflow_k8s/context_helper.py
+++ b/kedro_airflow_k8s/context_helper.py
@@ -68,7 +68,7 @@ class ContextHelper(object):
 
 
 class ContextHelper16(ContextHelper):
-    """ Variant for compatibility with Kedro 1.6 """
+    """Variant for compatibility with Kedro 1.6"""
 
     @property
     def project_name(self):

--- a/kedro_airflow_k8s/operators/start_mlflow_experiment.py
+++ b/kedro_airflow_k8s/operators/start_mlflow_experiment.py
@@ -20,6 +20,7 @@ class StartMLflowExperimentOperator(BaseOperator):
         mlflow_url: str,
         experiment_name: str,
         task_id: str = "start_mlflow_run",
+        image: str = None,
         **kwargs,
     ) -> None:
         """
@@ -33,6 +34,7 @@ class StartMLflowExperimentOperator(BaseOperator):
         super().__init__(task_id=task_id, **kwargs)
         self.experiment_name = experiment_name
         self.mlflow_url = mlflow_url
+        self.image = image
 
     def create_mlflow_client(self):
         """
@@ -89,6 +91,9 @@ class StartMLflowExperimentOperator(BaseOperator):
             )
 
         run_id = mlflow_client.create_run(experiment_id).info.run_id
+        if self.image is not None:
+            mlflow_client.log_param(run_id, "image", self.image)
+
         context["ti"].xcom_push("mlflow_run_id", run_id)
 
         return run_id


### PR DESCRIPTION
Docker image of the pods that run kedro nodes is now logged as run param - so we know exactly what image was used to build the given model.

---
Keep in mind: 
- [ ] Documentation updates
- [x] [Changelog](CHANGELOG.md) updates 
