### PR TITLE
Issue/61 configurable start date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+-   Run config contains optional start_date in format YYYYMMDD, if not specified default is left to `days_ago(2)` 
+
 ## [0.5.3] - 2021-07-12
 
 -   Support for airflow macro parameters and variables

--- a/docs/source/02_installation/02_configuration.md
+++ b/docs/source/02_installation/02_configuration.md
@@ -33,6 +33,9 @@ run_config:
 
     # Apache Airflow cron expression for scheduled runs
     cron_expression: "@daily"
+        
+    # Optional start date in format YYYYMMDD, if not provided `days_ago(2)` is used instead
+    start_date: "20210721"
 
     # Optional pipeline description
     description: "Very Important Pipeline"

--- a/kedro_airflow_k8s/airflow_dag_template.j2
+++ b/kedro_airflow_k8s/airflow_dag_template.j2
@@ -6,6 +6,7 @@ from airflow.utils.dates import days_ago
 from airflow.utils.task_group import TaskGroup
 from airflow.sensors.external_task import ExternalTaskSensor
 from datetime import timedelta
+from datetime import datetime
 
 EXPERIMENT_NAME = "{{ config.run_config.experiment_name | slugify }}"
 
@@ -30,7 +31,7 @@ with DAG(
     description='{{ config.run_config.description }}',
     default_args=args,
     schedule_interval={% if schedule_interval %}'{{ schedule_interval }}'{% else %}None{% endif %},
-    start_date=days_ago(2),
+    start_date={% if config.run_config.start_date %}datetime({{ config.run_config.start_date[0:4] }}, {{ config.run_config.start_date[4:6] }}, {{ config.run_config.start_date[6:8] }}){% else %}days_ago(2){% endif %},
     tags=['commit_sha:{{ git_info.commit_sha }}',
             'generated_with_kedro_airflow_k8s:{{ kedro_airflow_k8s_version }}',
             'experiment_name:'+EXPERIMENT_NAME],

--- a/kedro_airflow_k8s/airflow_dag_template.j2
+++ b/kedro_airflow_k8s/airflow_dag_template.j2
@@ -31,7 +31,7 @@ with DAG(
     description='{{ config.run_config.description }}',
     default_args=args,
     schedule_interval={% if schedule_interval %}'{{ schedule_interval }}'{% else %}None{% endif %},
-    start_date={% if config.run_config.start_date %}datetime({{ config.run_config.start_date[0:4] }}, {{ config.run_config.start_date[4:6] }}, {{ config.run_config.start_date[6:8] }}){% else %}days_ago(2){% endif %},
+    start_date={% if config.run_config.start_date %}datetime({{ config.run_config.start_date[0:4] }}, int('{{ config.run_config.start_date[4:6] }}'), int('{{ config.run_config.start_date[6:8] }}')){% else %}days_ago(2){% endif %},
     tags=['commit_sha:{{ git_info.commit_sha }}',
             'generated_with_kedro_airflow_k8s:{{ kedro_airflow_k8s_version }}',
             'experiment_name:'+EXPERIMENT_NAME],

--- a/kedro_airflow_k8s/config.py
+++ b/kedro_airflow_k8s/config.py
@@ -34,6 +34,9 @@ run_config:
     # Apache Airflow cron expression for scheduled runs
     cron_expression: "@daily"
 
+    # Optional start date in format YYYYMMDD
+    #start_date: "20210721"
+
     # Optional pipeline description
     #description: "Very Important Pipeline"
 
@@ -270,6 +273,13 @@ class RunConfig(Config):
     @property
     def cron_expression(self):
         return self._get_or_default("cron_expression", "@daily")
+
+    @property
+    def start_date(self):
+        start_date = self._get_or_default("start_date", None)
+        if start_date:
+            start_date = str(start_date)
+        return start_date
 
     @property
     def description(self):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -134,7 +134,7 @@ class TestPluginCLI:
         assert '"target/k8s.io": "mammoth"' in dag_content
         assert "startup_timeout=120" in dag_content
         assert 'pipeline="test_pipeline_name"' in dag_content
-        assert "start_date=datetime(2021, 07, 21)" in dag_content
+        assert "start_date=datetime(2021, int('07'), int('21'))" in dag_content
 
         assert (
             """secrets=[

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -66,6 +66,7 @@ class TestPluginCLI:
                     "experiment_name": "kedro_airflow_k8s",
                     "cron_expression": None,
                     "startup_timeout": 120,
+                    "start_date": "20210721",
                     "volume": {
                         "access_modes": ["ReadWriteMany"],
                         "size": "3Gi",
@@ -133,6 +134,7 @@ class TestPluginCLI:
         assert '"target/k8s.io": "mammoth"' in dag_content
         assert "startup_timeout=120" in dag_content
         assert 'pipeline="test_pipeline_name"' in dag_content
+        assert "start_date=datetime(2021, 07, 21)" in dag_content
 
         assert (
             """secrets=[

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -17,6 +17,7 @@ run_config:
     cron_expression: "@hourly"
     description: "test pipeline"
     startup_timeout: 120
+    start_date: 20200102
     volume:
         storageclass: kms
         size: 3Gi
@@ -82,6 +83,7 @@ class TestPluginConfig(unittest.TestCase):
         assert cfg.run_config.run_name == "test-experiment-branch"
         assert cfg.run_config.cron_expression == "@hourly"
         assert cfg.run_config.description == "test pipeline"
+        assert cfg.run_config.start_date == "20200102"
         assert cfg.run_config.volume
         assert cfg.run_config.volume.storageclass == "kms"
         assert cfg.run_config.volume.size == "3Gi"
@@ -164,6 +166,7 @@ class TestPluginConfig(unittest.TestCase):
         assert cfg.run_config.startup_timeout == 600
         assert cfg.run_config.cron_expression == "@daily"
         assert cfg.run_config.description is None
+        assert cfg.run_config.start_date is None
 
         assert cfg.run_config.volume
         assert cfg.run_config.volume.disabled is False


### PR DESCRIPTION
start_date is configurable via run_config. 

Resolves `61`

---
Keep in mind: 
- [x] Documentation updates
- [x] [Changelog](CHANGELOG.md) updates 
