### PR TITLE
Airflow 2 1 1 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+-   FIX: Adjusted operators to make them compatible with Airflow >= 2.1.1
+
 ## [0.6.3] - 2021-08-04
 
 -   FIX: Avoid file based Jinja template for `data-volume-init`

--- a/kedro_airflow_k8s/operators/data_volume_init.py
+++ b/kedro_airflow_k8s/operators/data_volume_init.py
@@ -67,6 +67,7 @@ class DataVolumeInitOperator(KubernetesPodOperator):
         image_pull_secrets: str = None,
         source: str = "/home/kedro/data",
         task_id: str = "data_volume_init",
+        **kwargs,
     ):
         """
         :param namespace: pod is started in this k8s namespace
@@ -93,6 +94,7 @@ class DataVolumeInitOperator(KubernetesPodOperator):
             startup_timeout_seconds=startup_timeout,
             pod_template_file=self.definition,
             image_pull_policy=image_pull_policy,
+            **kwargs,
         )
 
     @property

--- a/kedro_airflow_k8s/operators/node_pod.py
+++ b/kedro_airflow_k8s/operators/node_pod.py
@@ -47,6 +47,7 @@ class NodePodOperator(KubernetesPodOperator):
         secrets: Optional[List[Secret]] = None,
         source: str = "/home/kedro/data",
         parameters: Optional[str] = "",
+        **kwargs,
     ):
         """
 
@@ -122,6 +123,7 @@ class NodePodOperator(KubernetesPodOperator):
             tolerations=self.create_tolerations(tolerations),
             annotations=annotations,
             secrets=secrets,
+            **kwargs,
         )
 
     def execute(self, context):


### PR DESCRIPTION
Staring with Airflow 2.1.1, default DAG args are passed as additional parameter to operators (https://github.com/apache/airflow/blob/2.1.1/airflow/models/baseoperator.py#L180), so we need to allow `**kwargs` in our operators (and pass it downstream)

---
Keep in mind: 
- [ ] Documentation updates
- [x] [Changelog](CHANGELOG.md) updates 
