### PR TITLE
Support for passing Authorization header for secured Airflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+-   Support for passing Authorization header for secured Airflow API endpoint (via env variable: `AIRFLOW_API_TOKEN`)
+
 ## [0.6.5] - 2021-08-05
 
 -   FIX: Adjust service account setup for image based tasks

--- a/docs/source/03_getting_started/04_authentication.md
+++ b/docs/source/03_getting_started/04_authentication.md
@@ -1,0 +1,63 @@
+# Authentication to Airflow API
+
+Most of the operations provided by plugin uses Airflow API to either list dags or trigger them. 
+By default, access to Airflow API is blocked and in order to enable it you need to modify `api.auth_backend` config variable [as described in the documentation](https://airflow.apache.org/docs/apache-airflow/stable/security/api.html). Suggested setting for best plugin usage experience is to disable authentication on Airflow by setting value `airflow.api.auth.backend.default` and install middleware proxy blocking access to the API paths to users without expected JWT token in the header.
+
+Sample configuration for istio filter and token issued by gcloud SDK can look like:
+
+```yaml
+apiVersion: security.istio.io/v1beta1
+kind: RequestAuthentication
+metadata:
+  name: jwt-token-verification
+spec:
+  selector:
+    matchLabels:
+      component: webserver
+  jwtRules:
+  - issuer: https://accounts.google.com
+    jwksUri: https://www.googleapis.com/oauth2/v3/certs
+    audiences:
+    - 32555940559.apps.googleusercontent.com # google token generator
+---
+apiVersion: security.istio.io/v1beta1
+kind: AuthorizationPolicy
+metadata:
+  name: airflow-api-access
+spec:
+  selector:
+    matchLabels:
+      component: webserver
+  rules:
+  # allow all users to access UI, but not API
+  # UI has its own access management
+  - to:
+    - operation:
+        notPaths: ["/api/*"]
+  # enforce JWT token on API
+  - when:
+    - key: request.auth.audiences
+      values:
+      - 32555940559.apps.googleusercontent.com # isued by gcloud sdk
+    - key: request.auth.presenter
+      values:
+      - [service-account]@[google-project].iam.gserviceaccount.com
+    to:
+    - operation:
+        paths: ["/api/*"]
+```
+
+This setup ensures that all requests to the API paths are validated by Istio by checking the content of JWT token issued by Google (using [gcloud auth print-identity-token](https://cloud.google.com/sdk/gcloud/reference/auth/print-identity-token)]. In order to validate other tokens, modify `audiences` and `jwtRules` accordingly.
+
+Token can be passed to `kedro airflow-k8s` commands by using environment variable `AIRFLOW_API_TOKEN`, for example:
+
+```console
+$ AIRFLOW_API_TOKEN=eyJhbGci... kedro airflow-k8s list-pipelines 2> /dev/null
+2021-08-13 14:59:13,635 - root - INFO - Registered hooks from 3 installed plugin(s): kedro-kubeflow-0.3.1, kedro-mlflow-0.7.2
+2021-08-13 14:59:13,680 - root - INFO - Registered CLI hooks from 1 installed plugin(s): kedro-telemetry-0.1.1
+2021-08-13 15:05:38,800 - kedro_telemetry.plugin - INFO - You have opted into product usage analytics.
+2021-08-13 14:59:14,764 - kedro.framework.session.store - INFO - `read()` not implemented for `BaseSessionStore`. Assuming empty store.
+Name     ID
+-------  ------------------
+model1   model1-branch-name
+```

--- a/docs/source/03_getting_started/index.rst
+++ b/docs/source/03_getting_started/index.rst
@@ -7,3 +7,4 @@ Getting started
    Quickstart <01_quickstart.md>
    Google Cloud Platform support <02_gcp.md>
    Kedro-Mlflow integration <03_mlflow.md>
+   Authentication to Airflow API <04_authentication.md>

--- a/kedro_airflow_k8s/airflow.py
+++ b/kedro_airflow_k8s/airflow.py
@@ -61,6 +61,9 @@ class AirflowClient:
         )
         adapter = HTTPAdapter(max_retries=retry_strategy)
         session = requests.Session()
+        if 'AIRFLOW_API_TOKEN' in os.environ:
+            token = os.environ['AIRFLOW_API_TOKEN']
+            session.headers.update({'Authorization': 'Bearer ' + token})
         session.mount("https://", adapter)
         session.mount("http://", adapter)
 

--- a/kedro_airflow_k8s/airflow.py
+++ b/kedro_airflow_k8s/airflow.py
@@ -61,9 +61,9 @@ class AirflowClient:
         )
         adapter = HTTPAdapter(max_retries=retry_strategy)
         session = requests.Session()
-        if 'AIRFLOW_API_TOKEN' in os.environ:
-            token = os.environ['AIRFLOW_API_TOKEN']
-            session.headers.update({'Authorization': 'Bearer ' + token})
+        if "AIRFLOW_API_TOKEN" in os.environ:
+            token = os.environ["AIRFLOW_API_TOKEN"]
+            session.headers.update({"Authorization": "Bearer " + token})
         session.mount("https://", adapter)
         session.mount("http://", adapter)
 

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ EXTRA_REQUIRE = {
         "pre-commit==2.9.3",
         "apache-airflow[kubernetes]==2.0.1",
         "apache-airflow-providers-cncf-kubernetes==1.1.0",
-        "mlflow==1.14.1",
+        "mlflow-skinny==1.19.0",
         "sqlalchemy==1.3.23",
         "responses>=0.13.0",
     ],

--- a/tests/test_airflow.py
+++ b/tests/test_airflow.py
@@ -1,4 +1,5 @@
 import os
+
 import pytest
 import responses
 
@@ -12,8 +13,8 @@ class TestAirflow:
             "https://test.airflow.com", max_retries=0, retry_interval=0
         )
 
-        if 'AIRFLOW_API_TOKEN' in os.environ:
-            del os.environ['AIRFLOW_API_TOKEN']
+        if "AIRFLOW_API_TOKEN" in os.environ:
+            del os.environ["AIRFLOW_API_TOKEN"]
 
     @responses.activate
     def test_get_dag(self, client):
@@ -220,7 +221,7 @@ class TestAirflow:
 
     @responses.activate
     def test_use_of_authorization_token(self, client):
-        os.environ['AIRFLOW_API_TOKEN'] = "eyJhbG..."
+        os.environ["AIRFLOW_API_TOKEN"] = "eyJhbG..."
         response_data = {
             "dag_id": "test_id",
             "tags": [{"name": "commit_sha:123456"}],
@@ -231,7 +232,10 @@ class TestAirflow:
             json=response_data,
         )
 
-        dag = client.get_dag("test_id")
+        client.get_dag("test_id")
 
-        assert 'Authorization' in responses.calls[0].request.headers
-        assert responses.calls[0].request.headers['Authorization'] == 'Bearer eyJhbG...'
+        assert "Authorization" in responses.calls[0].request.headers
+        assert (
+            responses.calls[0].request.headers["Authorization"]
+            == "Bearer eyJhbG..."
+        )


### PR DESCRIPTION
This change provides ability to set Authorization header while accessing Airflow API.
The token can be injected via the environment variable, in the mlflow-like way here: https://github.com/mlflow/mlflow/blob/master/mlflow/utils/rest_utils.py#L44 and here: https://github.com/mlflow/mlflow/blob/master/mlflow/tracking/_tracking_service/utils.py#L125

---
Keep in mind: 
- [x] Documentation updates
- [x] [Changelog](CHANGELOG.md) updates 
