### PR TITLE
Log additional params pointing to the Airflow DAG run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 -   Support for passing Authorization header for secured Airflow API endpoint (via env variable: `AIRFLOW_API_TOKEN`)
+-   Logging `dag_id` and `execution_date` in mlflow run params
 
 ## [0.6.5] - 2021-08-05
 

--- a/kedro_airflow_k8s/operators/start_mlflow_experiment.py
+++ b/kedro_airflow_k8s/operators/start_mlflow_experiment.py
@@ -94,6 +94,11 @@ class StartMLflowExperimentOperator(BaseOperator):
         if self.image is not None:
             mlflow_client.log_param(run_id, "image", self.image)
 
+        mlflow_client.log_param(run_id, "dag_id", context["dag"].dag_id)
+        mlflow_client.log_param(
+            run_id, "execution_date", str(context.get("execution_date"))
+        )
+
         context["ti"].xcom_push("mlflow_run_id", run_id)
 
         return run_id

--- a/tests/operators/test_start_mlflow_experiment_operator.py
+++ b/tests/operators/test_start_mlflow_experiment_operator.py
@@ -23,6 +23,7 @@ class TestStartMLflowExperimentOperator(unittest.TestCase):
         task_instance = TaskInstance(task=task, execution_date=execution_date)
         return {
             "dag": dag,
+            "execution_date": execution_date,
             "ts": execution_date.isoformat(),
             "task": task,
             "ti": task_instance,
@@ -126,7 +127,7 @@ class TestStartMLflowExperimentOperator(unittest.TestCase):
                 context = self.create_context(op)
                 op.execute(context=context)
 
-    def test_log_docker_image_within_run(self):
+    def test_logging_run_params(self):
         with mock.patch.object(
             start_mlflow_experiment.StartMLflowExperimentOperator,
             "create_mlflow_client",
@@ -153,6 +154,14 @@ class TestStartMLflowExperimentOperator(unittest.TestCase):
             context = self.create_context(op)
 
             assert op.execute(context=context) == "another-run-id"
-            mlflow_client.log_param.assert_called_with(
+            mlflow_client.log_param.assert_any_call(
                 "another-run-id", "image", "registry.com/someimage:aabbcc"
+            )
+            mlflow_client.log_param.assert_any_call(
+                "another-run-id", "dag_id", "dag"
+            )
+            mlflow_client.log_param.assert_any_call(
+                "another-run-id",
+                "execution_date",
+                str(context["execution_date"]),
             )


### PR DESCRIPTION
To allow backtracing ("what airflow run caused this mlflow run? What were the logs?")

---
Keep in mind: 
- [ ] Documentation updates
- [x] [Changelog](CHANGELOG.md) updates 
