### PR TITLE
GCSfs bumped

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ EXTRA_REQUIRE = {
         "sphinx_rtd_theme==0.5.2",
     ],
     "gcp": [
-        "gcsfs>=0.7.2, <0.8.0",
+        "gcsfs<0.8.0",
     ],
     "aws": ["s3fs>=0.6.1"],
     "mlflow": ["kedro-mlflow==0.4.1"],

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ EXTRA_REQUIRE = {
         "sphinx_rtd_theme==0.5.2",
     ],
     "gcp": [
-        "gcsfs>=0.6.2, <0.7.0",
+        "gcsfs>=0.7.2, <0.8.0",
     ],
     "aws": ["s3fs>=0.6.1"],
     "mlflow": ["kedro-mlflow==0.4.1"],


### PR DESCRIPTION
Bumped version of `gcsfs` library to match fsspec in kedro 0.17.4.

Resolves #88 

---
Keep in mind: 
- [ ] Documentation updates
- [ ] [Changelog](CHANGELOG.md) updates 
