### PR TITLE
Issue/98 authentication to mlflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+-   Support for generation of authentication header for secured MLflow API endpoint (via GOOGLE_APPLICATION_CREDENTIALS)
+
 ## [0.6.6] - 2021-08-16
 
 -   Support for passing Authorization header for secured Airflow API endpoint (via env variable: `AIRFLOW_API_TOKEN`)

--- a/docs/source/02_installation/02_configuration.md
+++ b/docs/source/02_installation/02_configuration.md
@@ -151,6 +151,13 @@ run_config:
         # Time difference with the previous execution to look at (minutes),
         # the default is 0 meaning no difference
           execution_delta: 10
+
+    # Optional authentication to MLflow API    
+    authentication:
+      # Strategy that generates the tokens, supported values are: 
+      # - Null
+      # - GoogleOAuth2 (generating OAuth2 tokens for service account provided by GOOGLE_APPLICATION_CREDENTIALS)  
+      type: GoogleOAuth2 
 ```
 
 ## Indicate resources in pipeline nodes

--- a/docs/source/03_getting_started/03_mlflow.md
+++ b/docs/source/03_getting_started/03_mlflow.md
@@ -28,13 +28,14 @@ And re-push the image to the remote registry.
 
 # Authentication to MLflow API
 
-Given that Airflow has access to `GOOGLE_APPLICATION_CREDENTIALS` variables, it's possible to configure plugin
+Given that Airflow has access to `GOOGLE_APPLICATION_CREDENTIALS` variable, it's possible to configure plugin
 to use Google service account to authenticate to secured MLflow API endpoint, by generating OAuth2 token.
 
-All is required to have `GOOGLE_APPLICATION_CREDENTIALS` setup in Airflow and MLflow to be protected by Google as an
-issuer.
+All is required to have `GOOGLE_APPLICATION_CREDENTIALS` environment variable setup in Airflow installation and MLflow
+to be protected by Google as an issuer. The other thing is to have environment variable `GOOGLE_AUDIENCE` which
+indicates OAuth2 audience the token should be issued for.
 
-Also, configuration requires the following:
+Also, plugin configuration requires the following:
 
 ```yaml
 run_config:

--- a/docs/source/03_getting_started/03_mlflow.md
+++ b/docs/source/03_getting_started/03_mlflow.md
@@ -25,3 +25,23 @@ And re-push the image to the remote registry.
 
 > If `kedro-mlflow` is not installed as dependency and configuration is not in place (missing `kedro mlflow init`), the 
 > MLflow experiment will not be initialized and available for pipeline tasks in Apache Airflow DAG.
+
+# Authentication to MLflow API
+
+Given that Airflow has access to `GOOGLE_APPLICATION_CREDENTIALS` variables, it's possible to configure plugin
+to use Google service account to authenticate to secured MLflow API endpoint, by generating OAuth2 token.
+
+All is required to have `GOOGLE_APPLICATION_CREDENTIALS` setup in Airflow and MLflow to be protected by Google as an
+issuer.
+
+Also, configuration requires the following:
+
+```yaml
+run_config:
+  authentication:
+    type: GoogleOAuth2
+```
+
+> NOTE: Authentication is an optional element and is used when starting MLflow experiment, so if MLflow is enabled in
+> project configuration. It does not setup authentication inside Kedro nodes, this has to be handled by the project.
+> Check GoogleOAuth2Handler class for details.

--- a/docs/source/03_getting_started/04_authentication.md
+++ b/docs/source/03_getting_started/04_authentication.md
@@ -38,7 +38,7 @@ spec:
   - when:
     - key: request.auth.audiences
       values:
-      - 32555940559.apps.googleusercontent.com # isued by gcloud sdk
+      - 32555940559.apps.googleusercontent.com # issued by gcloud sdk
     - key: request.auth.presenter
       values:
       - [service-account]@[google-project].iam.gserviceaccount.com

--- a/kedro_airflow_k8s/airflow_dag_template.j2
+++ b/kedro_airflow_k8s/airflow_dag_template.j2
@@ -45,6 +45,7 @@ with DAG(
         experiment_name=EXPERIMENT_NAME,
         mlflow_url='{{ mlflow_url }}',
         image="{{ image }}",
+        auth_handler={{ config.run_config.auth_config.type }}AuthHandler()
     )
     {% endif %}
 

--- a/kedro_airflow_k8s/config.py
+++ b/kedro_airflow_k8s/config.py
@@ -160,6 +160,13 @@ run_config:
         # Time difference with the previous execution to look at (minutes),
         # the default is 0 meaning no difference
         #  execution_delta: 10
+    # Optional authentication to MLflow API
+    #authentication:
+      # Strategy that generates the tokens, supported values are:
+      # - Null
+      # - GoogleOAuth2 (generating OAuth2 tokens for service account provided by
+      # GOOGLE_APPLICATION_CREDENTIALS)
+      #type: GoogleOAuth2
 """
 
 
@@ -251,6 +258,12 @@ class ExternalDependencyConfig(Config):
         return self._get_or_default("timeout", 60 * 24)
 
 
+class AuthenticationConfig(Config):
+    @property
+    def type(self):
+        return self._get_or_default("type", "Null")
+
+
 class RunConfig(Config):
     @property
     def image(self):
@@ -326,6 +339,11 @@ class RunConfig(Config):
     @property
     def service_account_name(self):
         return self._get_or_default("service_account_name", None)
+
+    @property
+    def auth_config(self):
+        cfg = self._get_or_default("authentication", {"type": "Null"})
+        return AuthenticationConfig(cfg)
 
     def _get_prefix(self):
         return "run_config."

--- a/kedro_airflow_k8s/operators/start_mlflow_experiment.py
+++ b/kedro_airflow_k8s/operators/start_mlflow_experiment.py
@@ -4,7 +4,7 @@ Module contains Apache Airflow operator that starts experiment in mlflow.
 import abc
 import logging
 import os
-from typing import Dict
+from typing import Dict, Optional
 
 from airflow.operators.python import BaseOperator
 from airflow.utils.decorators import apply_defaults
@@ -28,7 +28,9 @@ class NullAuthHandler(AuthHandler):
 class GoogleOAuth2AuthHandler(AuthHandler):
     log = logging.getLogger("GoogleOAuth2AuthHandler")
 
-    def __init__(self, audience: str):
+    def __init__(self, audience: Optional[str] = None):
+        if not audience:
+            audience = os.environ["GOOGLE_AUDIENCE"]
         self.audience = audience
 
     def obtain_token(self) -> str:

--- a/kedro_airflow_k8s/operators/start_mlflow_experiment.py
+++ b/kedro_airflow_k8s/operators/start_mlflow_experiment.py
@@ -1,11 +1,54 @@
 """
 Module contains Apache Airflow operator that starts experiment in mlflow.
 """
+import abc
 import logging
+import os
 from typing import Dict
 
 from airflow.operators.python import BaseOperator
 from airflow.utils.decorators import apply_defaults
+
+
+class AuthHandler:
+    @abc.abstractmethod
+    def obtain_token(self) -> str:
+        pass
+
+
+class NullAuthHandler(AuthHandler):
+    @staticmethod
+    def instance():
+        return NullAuthHandler()
+
+    def obtain_token(self) -> str:
+        return ""
+
+
+class GoogleOAuth2AuthHandler(AuthHandler):
+    log = logging.getLogger("GoogleOAuth2AuthHandler")
+
+    def __init__(self, audience: str):
+        self.audience = audience
+
+    def obtain_token(self) -> str:
+        from google.auth.transport.requests import Request
+        from google.oauth2 import id_token
+
+        gac = os.environ.get("GOOGLE_APPLICATION_CREDENTIALS", None)
+        token = ""
+
+        if gac:
+            try:
+                self.log.debug(
+                    "Attempt to get JWT token for %s." + self.audience
+                )
+                token = id_token.fetch_id_token(Request(), self.audience)
+                self.log.info("Obtained JWT token for authentication.")
+            except Exception as e:
+                self.log.error("Failed to obtain IAP access token. " + str(e))
+            finally:
+                return token
 
 
 class StartMLflowExperimentOperator(BaseOperator):
@@ -21,6 +64,7 @@ class StartMLflowExperimentOperator(BaseOperator):
         experiment_name: str,
         task_id: str = "start_mlflow_run",
         image: str = None,
+        auth_handler: AuthHandler = NullAuthHandler.instance(),
         **kwargs,
     ) -> None:
         """
@@ -35,6 +79,7 @@ class StartMLflowExperimentOperator(BaseOperator):
         self.experiment_name = experiment_name
         self.mlflow_url = mlflow_url
         self.image = image
+        self.auth_handler = auth_handler
 
     def create_mlflow_client(self):
         """
@@ -56,6 +101,10 @@ class StartMLflowExperimentOperator(BaseOperator):
         :param context: Airflow context
         :return: mlflow experiment run_id
         """
+        auth_token = self.auth_handler.obtain_token()
+        if auth_token:
+            os.environ["MLFLOW_TRACKING_TOKEN"] = auth_token
+
         from mlflow.protos.databricks_pb2 import (
             RESOURCE_ALREADY_EXISTS,
             ErrorCode,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -97,6 +97,7 @@ class TestPluginCLI:
                             "requests": {"cpu": "16", "memory": "128Gi"},
                         },
                     },
+                    "authentication": {"type": "GoogleOAuth2"},
                 },
             }
         )
@@ -139,6 +140,7 @@ class TestPluginCLI:
         assert "start_date=datetime(2021, int('07'), int('21'))" in dag_content
         assert 'image_pull_secrets="pull_secrets"' in dag_content
         assert 'service_account_name="service_account"' in dag_content
+        assert "auth_handler=GoogleOAuth2AuthHandler()" in dag_content
 
         assert (
             """secrets=[

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -171,6 +171,7 @@ class TestPluginConfig(unittest.TestCase):
         assert cfg.run_config.cron_expression == "@daily"
         assert cfg.run_config.description is None
         assert cfg.run_config.start_date is None
+        assert cfg.run_config.auth_config.type == "Null"
 
         assert cfg.run_config.volume
         assert cfg.run_config.volume.disabled is False


### PR DESCRIPTION
Based on GOOGLE_APPLICATION_CREDENTIALS and GOOGLE_AUDIENCE issues MLFLOW_TRACKING_TOKEN for StartMLflowExperiment. 

Resolves `#98`

---
Keep in mind: 
- [x] Documentation updates
- [x] [Changelog](CHANGELOG.md) updates 
