### PR TITLE
Support k8s env_vars + new MLFlow auth handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+-   FIX: Fix default config template
+-   Support populating k8s node env_vars from Airflow variables
+-   Generalize auth handler
+-   Added `VarsAuthHandler` for MLflow authentication which gets credentials from Airflow variables
+-   Changed logging level for pod creation request to debug
+
 ## [0.6.7] - 2021-09-01
 
 -   Support for generation of authentication header for secured MLflow API endpoint (via GOOGLE_APPLICATION_CREDENTIALS)

--- a/docs/source/03_getting_started/03_mlflow.md
+++ b/docs/source/03_getting_started/03_mlflow.md
@@ -28,6 +28,8 @@ And re-push the image to the remote registry.
 
 # Authentication to MLflow API
 
+## GoogleOAuth2
+
 Given that Airflow has access to `GOOGLE_APPLICATION_CREDENTIALS` variable, it's possible to configure plugin
 to use Google service account to authenticate to secured MLflow API endpoint, by generating OAuth2 token.
 
@@ -42,6 +44,22 @@ run_config:
   authentication:
     type: GoogleOAuth2
 ```
+
+## Vars
+
+If you store your credentials in Airflow secrets backend, e.g. HashiCorp vault, it's possible to configure the plugin
+to use Airflow Variables as MLFlow API credentials.
+
+Names of the variables need to match expected MLflow environment variable names, e.g. `MLFLOW_TRACKING_TOKEN`.
+You specify them in the authentiation config. For instance, setting up Basic Authentication requires the following:
+
+```yaml
+run_config:
+  authentication:
+    type: Vars
+    params: ["MLFLOW_TRACKING_USERNAME", "MLFLOW_TRACKING_PASSWORD"]
+```
+
 
 > NOTE: Authentication is an optional element and is used when starting MLflow experiment, so if MLflow is enabled in
 > project configuration. It does not setup authentication inside Kedro nodes, this has to be handled by the project.

--- a/kedro_airflow_k8s/airflow_dag_template.j2
+++ b/kedro_airflow_k8s/airflow_dag_template.j2
@@ -45,7 +45,11 @@ with DAG(
         experiment_name=EXPERIMENT_NAME,
         mlflow_url='{{ mlflow_url }}',
         image="{{ image }}",
-        auth_handler={{ config.run_config.auth_config.type }}AuthHandler()
+        auth_handler={{ config.run_config.auth_config.type }}AuthHandler({%- if config.run_config.auth_config.params -%}[
+        {%- for param in config.run_config.auth_config.params -%}
+            "{{ param }}",
+        {%- endfor -%}]
+        {%- endif -%})
     )
     {% endif %}
 
@@ -145,8 +149,14 @@ with DAG(
                 {{ param }}:{{'{{ var.value.'}}{{  param }} {{ '}}' }},
                 {%- endfor %}
             """,
+            env_vars={
+            {%- for var in config.run_config.env_vars %}
+                "{{ var }}": "{{'{{ var.value.'}}{{ var }} {{ '}}' }}",
+            {%- endfor %}
+            },
         )
     {% endfor %}
+
 
     {% for parent_node, child_nodes in dependencies.items() -%}
     {% for child in child_nodes %}

--- a/kedro_airflow_k8s/operators/node_pod.py
+++ b/kedro_airflow_k8s/operators/node_pod.py
@@ -132,7 +132,7 @@ class NodePodOperator(KubernetesPodOperator):
         :param context:
         :return:
         """
-        logging.info(self.create_pod_request_obj())
+        logging.debug(self.create_pod_request_obj())
         return super().execute(context)
 
     @staticmethod

--- a/tests/operators/test_start_mlflow_experiment_operator.py
+++ b/tests/operators/test_start_mlflow_experiment_operator.py
@@ -179,7 +179,9 @@ class TestStartMLflowExperimentOperator(unittest.TestCase):
             if "MLFLOW_TRACKING_TOKEN" in os.environ:
                 del os.environ["MLFLOW_TRACKING_TOKEN"]
             auth_handler = MagicMock()
-            auth_handler.obtain_token.return_value = "TEST_JWT_TOKEN"
+            auth_handler.obtain_credentials.return_value = {
+                "MLFLOW_TRACKING_TOKEN": "TEST_JWT_TOKEN"
+            }
 
             create_mlflow_client.return_value = mlflow_client
             op = start_mlflow_experiment.StartMLflowExperimentOperator(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -67,6 +67,10 @@ run_config:
           timeout: 2
           check_existence: False
           execution_delta: 10
+    authentication:
+        type: Vars
+        params: ["MLFLOW_TRACKING_USERNAME", "MLFLOW_TRACKING_PASSWORD"]
+    env_vars: ["MLFLOW_TRACKING_USERNAME", "MLFLOW_TRACKING_PASSWORD"]
 """
 
 
@@ -162,6 +166,18 @@ class TestPluginConfig(unittest.TestCase):
         assert cfg.run_config.macro_params == ["ds", "prev_ds"]
         assert cfg.run_config.variables_params == ["env"]
 
+        assert cfg.run_config.auth_config
+        assert cfg.run_config.auth_config.type == "Vars"
+        assert cfg.run_config.auth_config.params == [
+            "MLFLOW_TRACKING_USERNAME",
+            "MLFLOW_TRACKING_PASSWORD",
+        ]
+
+        assert cfg.run_config.env_vars == [
+            "MLFLOW_TRACKING_USERNAME",
+            "MLFLOW_TRACKING_PASSWORD",
+        ]
+
     def test_defaults(self):
         cfg = PluginConfig({"run_config": {}})
 
@@ -172,6 +188,7 @@ class TestPluginConfig(unittest.TestCase):
         assert cfg.run_config.description is None
         assert cfg.run_config.start_date is None
         assert cfg.run_config.auth_config.type == "Null"
+        assert cfg.run_config.auth_config.params == []
 
         assert cfg.run_config.volume
         assert cfg.run_config.volume.disabled is False


### PR DESCRIPTION
We use an external Airflow secrets backend to store sensitive data, e.g. credentials. These credentials are accessible from Dags, so instead of setting up environment variables somewhere else I propose enabling passing Airflow variables as environment variables. 

This PR adds the possibility to pass Airflow variables (Variable.get) as environment variables to pods. Also, AuthHandler for MLflow tracking server  API has been refactored to accommodate other authentication types, e.g. Basic Authentication, and a new VarsAuthHandler has been added which receives credentials from the Airflow variables.

Logging pod creation request has been changed to debug to not leak sensitive data.

---
Keep in mind: 
- [ ] Documentation updates
- [ ] [Changelog](CHANGELOG.md) updates 
