### PR TITLE
Support multiline annotations with quotes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+-   Support annotations with quotes
 -   FIX: adding missing dependency package: tabulate
 -   FIX: Fix default config template
 -   Support populating k8s node env_vars from Airflow variables

--- a/kedro_airflow_k8s/airflow_dag_template.j2
+++ b/kedro_airflow_k8s/airflow_dag_template.j2
@@ -133,7 +133,7 @@ with DAG(
             ],
             annotations={
             {%- for key, value in resources[node.name].annotations.items() %}
-                "{{ key }}": "{{ value }}",
+                "{{ key }}": """{{ value | safe }}""",
             {%- endfor %}
             },
             secrets=[

--- a/kedro_airflow_k8s/config.py
+++ b/kedro_airflow_k8s/config.py
@@ -107,6 +107,10 @@ run_config:
             # Optional annotations to apply on pods
             #annotations:
               #iam.amazonaws.com/role: airflow
+              #vault.hashicorp.com/agent-inject-template-foo: |
+              # {{- with secret "database/creds/db-app" -}}
+              # postgres://{{ .Data.username }}:{{ .Data.password }}@postgres:5432/mydb
+              # {{- end }}
             # Optional list of kubernetes tolerations
             #tolerations:
                 #- key: "group"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -51,6 +51,10 @@ run_config:
                   effect: "NoExecute"
             annotations:
                 iam.amazonaws.com/role: airflow
+                vault.hashicorp.com/agent-inject-template-foo: |
+                  {{- with secret "database/creds/db-app" -}}
+                  postgres://{{ .Data.username }}:{{ .Data.password }}@postgres:5432/mydb
+                  {{- end }}
             requests:
                 cpu: "1"
                 memory: "1Gi"
@@ -116,6 +120,15 @@ class TestPluginConfig(unittest.TestCase):
         assert (
             resources.__default__.annotations["iam.amazonaws.com/role"]
             == "airflow"
+        )
+        assert (
+            resources.__default__.annotations[
+                "vault.hashicorp.com/agent-inject-template-foo"
+            ]
+            == """{{- with secret "database/creds/db-app" -}}
+postgres://{{ .Data.username }}:{{ .Data.password }}@postgres:5432/mydb
+{{- end }}
+"""
         )
         assert resources.__default__.requests
         assert resources.__default__.requests.cpu == "1"


### PR DESCRIPTION
This PR adds support for multiline quoted annotations. Basically, it makes the annotation value not escaped. 
Multiline annotations with quotes are used, for instance, with Hashicorp agents, e.g.

```
vault.hashicorp.com/agent-inject-template-foo: |
  {{- with secret "database/creds/db-app" -}}
  postgres://{{ .Data.username }}:{{ .Data.password }}@postgres:5432/mydb?sslmode=disable
  {{- end }}
```

---
Keep in mind: 
- [ ] Documentation updates
- [ ] [Changelog](CHANGELOG.md) updates 
