### PR TITLE
Support for custom k8s templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+-   Support for custom pod templates
 -   FIX: adding missing dependency package: tabulate
 -   FIX: Fix default config template
 -   Support populating k8s node env_vars from Airflow variables

--- a/docs/source/02_installation/02_configuration.md
+++ b/docs/source/02_installation/02_configuration.md
@@ -156,8 +156,33 @@ run_config:
     authentication:
       # Strategy that generates the tokens, supported values are: 
       # - Null
-      # - GoogleOAuth2 (generating OAuth2 tokens for service account provided by GOOGLE_APPLICATION_CREDENTIALS)  
+      # - GoogleOAuth2 (generating OAuth2 tokens for service account provided by GOOGLE_APPLICATION_CREDENTIALS)
+      # - Vars (credentials fetched from airflow Variable.get - specify variable keys,
+      # matching MLflow authentication env variable names, in `params`,
+      # e.g. ["MLFLOW_TRACKING_USERNAME", "MLFLOW_TRACKING_PASSWORD"])
       type: GoogleOAuth2 
+      #params: []
+
+    # Optional custom kubermentes pod templates applied on nodes basis
+    kubernetes_pod_templates:
+    # Name of the node you want to apply the custom template to.
+    # if you specify __default__, this template will be applied to all nodes.
+    # Otherwise it will be only applied to nodes tagged with `k8s_template:<node_name>`
+      spark:
+    # Kubernetes pod template.
+    # It's the full content of the pod-template file (as a string)
+    # `run_config.volume` and `MLFLOW_RUN_ID` env are disabled when this is set.
+    # Note: python F-string formatting is applied to this string, so
+    # you can also use some dynamic values, e.g. to calculate pod name.
+        template: |-
+          type: Pod
+          metadata:
+            name: {PodGenerator.make_unique_pod_id('{{ task_instance.task_id }}')}
+            labels:
+              spark_driver: {'{{ task_instance.task_id }}'}
+
+    # Optionally, you can also override the image
+    #   image:
 ```
 
 ## Indicate resources in pipeline nodes
@@ -178,6 +203,56 @@ node(func=train_model, inputs=["X_train", "y_train"], outputs="regressor", name=
 # k8s cluster default values are used
 node(func=evaluate_model, inputs=["X_train", "y_train"], outputs="regressor", name='evaluate_model')
 ```
+
+## Custom kubernetes pod templates
+
+You can provide custom kubernetes pod templates using `kubernetes_pod_templates`. Pod template to be used is based on
+the provided plugin configuration and presence of the tag `k8s_template` in `kedro` node definition.
+
+If no such tag is present, plugin will assign `__default__.template` from plugin `kubernetes_pod_templates` configuration, if exists.
+If no `__default__` is given in plugin `kubernetes_pod_templates` configuration or no `kubernetes_pod_templates` configuration is provided at all,
+the following plugin's default minimal pod template will be used.
+
+```yaml
+type: Pod
+  metadata:
+    name: {PodGenerator.make_unique_pod_id('{{ task_instance.task_id }}')}
+spec:
+  containers:
+    - name: base
+      env:
+        - name: MLFLOW_RUN_ID
+          value: {{ task_instance.xcom_pull(key="mlflow_run_id") }}
+  volumes:
+    - name: storage
+      persistentVolumeClaim:
+        claimName: {self._pvc_name}
+```
+
+where environment and volumes sections are present only if kedro mflow is used in the project and/or
+`run_config.volume` is not disabled.
+
+Note, that `claimName` is calculated the following way
+
+```python
+pvc_name = '{{ project_name | safe | slugify }}.{% raw %}{{ ts_nodash | lower  }}{% endraw %}'
+```
+
+If you do use a custom pod template and you want to keep the built-in mlflow/volume support you need to include
+these sections in your template as well.
+
+```python
+# train_model node is assigned a custom pod template from `spark` configuration, if no such configuration exists,
+# `__default__` is used, and if __default__ does not exist, the plugin's minimal pod template is used
+node(func=train_model, inputs=["X_train", "y_train"], outputs="regressor", name='train_model', tags=['k8s_template:spark'])
+# evaluate_model node is assigned a custom pod template `__default__` configuration and if it does not exist,
+# the plugin's default minimal pod template
+node(func=evaluate_model, inputs=["X_train", "y_train"], outputs="regressor", name='evaluate_model')
+```
+
+When using custom kubernetes pod templates the resulting pod configuration is a merge between
+properties provided via plugin settings, e.g. `resources.__default__.annotations`, and those specified in a
+template. In case of a conflict, plugin settings precede that of the template.
 
 ## Dynamic configuration support
 

--- a/kedro_airflow_k8s/airflow_dag_template.j2
+++ b/kedro_airflow_k8s/airflow_dag_template.j2
@@ -94,7 +94,11 @@ with DAG(
             namespace="{{config.run_config.namespace}}",
             volume_disabled={{config.run_config.volume.disabled}},
             pvc_name=pvc_name,
-            image="{{ image }}",
+            image={%- if k8s_templates[node.name].image -%}
+            "{{ k8s_templates[node.name].image }}",
+            {%- else -%}
+            "{{ image }}",
+            {%- endif %}
             image_pull_policy="{{ config.run_config.image_pull_policy }}",
             {%- if config.run_config.image_pull_secrets %}
             image_pull_secrets="{{ config.run_config.image_pull_secrets }}",
@@ -154,6 +158,9 @@ with DAG(
                 "{{ var }}": "{{'{{ var.value.'}}{{ var }} {{ '}}' }}",
             {%- endfor %}
             },
+            {%- if k8s_templates[node.name].template %}
+            kubernetes_pod_template=f"""{{ k8s_templates[node.name].template | safe }}""",
+            {%- endif %}
         )
     {% endfor %}
 

--- a/kedro_airflow_k8s/operators/node_pod.py
+++ b/kedro_airflow_k8s/operators/node_pod.py
@@ -47,6 +47,7 @@ class NodePodOperator(KubernetesPodOperator):
         secrets: Optional[List[Secret]] = None,
         source: str = "/home/kedro/data",
         parameters: Optional[str] = "",
+        kubernetes_pod_template: Optional[str] = None,
         **kwargs,
     ):
         """
@@ -84,6 +85,7 @@ class NodePodOperator(KubernetesPodOperator):
         self._volume_disabled = volume_disabled
         self._pvc_name = pvc_name
         self._mlflow_enabled = mlflow_enabled
+        self._kubernetes_pod_template = kubernetes_pod_template
 
         super().__init__(
             task_id=task_id,
@@ -167,6 +169,8 @@ class NodePodOperator(KubernetesPodOperator):
         :return: partial pod definition that should be complemented by other operator
                 parameters
         """
+        if self._kubernetes_pod_template:
+            return self._kubernetes_pod_template
         minimal_pod_template = f"""
 apiVersion: v1
 kind: Pod

--- a/kedro_airflow_k8s/template.py
+++ b/kedro_airflow_k8s/template.py
@@ -8,7 +8,7 @@ from jinja2.environment import TemplateStream
 from slugify import slugify
 
 from kedro_airflow_k8s import version
-from kedro_airflow_k8s.config import ResourceConfig
+from kedro_airflow_k8s.config import KubernetesPodTemplate, ResourceConfig
 
 
 def _get_mlflow_url(context_helper):
@@ -42,6 +42,23 @@ def _node_resources(nodes, config) -> Dict[str, ResourceConfig]:
         ]
         result[node.name] = (
             config[resources[0]] if resources else default_config
+        )
+    return result
+
+
+def _pod_templates(nodes, config) -> Dict[str, KubernetesPodTemplate]:
+
+    result = defaultdict(lambda: None)
+
+    default_config = config.__default__
+    for node in nodes:
+        templates = [
+            tag[len("k8s_template:") :]  # noqa: E203
+            for tag in node.tags
+            if "k8s_template:" in tag
+        ]
+        result[node.name] = (
+            config[templates[0]] if templates else default_config
         )
     return result
 
@@ -96,6 +113,10 @@ def _create_template_stream(
         secrets=context_helper.config.run_config.secrets,
         macro_params=context_helper.config.run_config.macro_params,
         variables_params=context_helper.config.run_config.variables_params,
+        k8s_templates=_pod_templates(
+            pipeline.nodes,
+            context_helper.config.run_config.kubernetes_pod_templates,
+        ),
     )
 
 

--- a/tests/operators/test_node_pod_operator.py
+++ b/tests/operators/test_node_pod_operator.py
@@ -1,5 +1,6 @@
 import unittest
 
+from airflow.kubernetes.pod_generator import PodGenerator
 from kubernetes.client.models.v1_env_var import V1EnvVar
 
 from kedro_airflow_k8s.operators.node_pod import NodePodOperator
@@ -123,3 +124,31 @@ class TestNodePodOperator(unittest.TestCase):
         assert len(pod.spec.image_pull_secrets) == 2
         assert pod.spec.image_pull_secrets[0].name == "top"
         assert pod.spec.image_pull_secrets[1].name == "secret"
+
+    def test_task_with_custom_k8s_pod_template(self):
+        task = NodePodOperator(
+            node_name="test_node_name",
+            namespace="airflow",
+            pvc_name="shared_storage",
+            image="registry.gitlab.com/test_image",
+            image_pull_policy="Always",
+            env="test-pipelines",
+            task_id="test-node-name",
+            volume_owner=100,
+            mlflow_enabled=False,
+            kubernetes_pod_template=f"""
+type: Pod
+metadata:
+  name: {PodGenerator.make_unique_pod_id('test-node-name')}'
+  labels:
+    test: mylabel
+spec:
+  containers:
+    - name: base
+""",
+        )
+        pod = task.create_pod_request_obj()
+
+        assert pod.metadata.name.startswith("test-node-name")
+        assert "test-node-name" != pod.metadata.name
+        assert pod.metadata.labels["test"] == "mylabel"


### PR DESCRIPTION
This PR adds support for custom Kubernetes templates. 

When dealing with complex pod requirements, i.e. many init containers, annotations, volumes, custom env etc., it's easier just to pass a custom template as as string than passing some attributes (currently customising pod template is very limited  anyway).

Custom pod templates borrows from `resources`, i.e. if you specify a `__default__` pod template it will be applied to all nodes. Otherwise, only to nodes tagged with a specific value, e.g. `k8s_template:spark`.
The value of the template is F-stringed, which allows you to include some dynamic content, e.g. 

```
type: Pod
  metadata:
    name: {PodGenerator.make_unique_pod_id('{{ task_instance.task_id }}')}
```

Custom pod templates also let you override the image - it's often the case that more complex containers require heavy images and you don't want all nodes to pay this penalty.

---
Keep in mind: 
- [ ] Documentation updates
- [ ] [Changelog](CHANGELOG.md) updates 
