### PR TITLE
Missing jinja template in target package.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 - Support for failure notifications via slack
+- FIX: Missing jinja template for dataproc init script
 
 ## [0.7.0] - 2021-10-19
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,6 @@
 include kedro_airflow_k8s/airflow_dag_template.j2
 include kedro_airflow_k8s/airflow_spark_task_template.j2
+include kedro_airflow_k8s/dataproc_init_script_template.j2
 include kedro_airflow_k8s/operators/data_volume_init_template.j2
 include templates/github-on-merge-to-master.yml
 include templates/github-on-push.yml


### PR DESCRIPTION
Manifest was missing one of the jinja templates, which caused it's absence in released package. 

---
Keep in mind: 
- [ ] Documentation updates
- [x] [Changelog](CHANGELOG.md) updates 
