### PR TITLE
Add mlflow run id as env variable to pyspark pipelines.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+-   `MLFLOW_RUN_ID` passed as environment variable to dataproc oriented pipelines
+
 ## [0.7.2] - 2021-10-25
 
 -   Support annotations with quotes

--- a/kedro_airflow_k8s/airflow_dag_template.j2
+++ b/kedro_airflow_k8s/airflow_dag_template.j2
@@ -158,7 +158,14 @@ with DAG(
         PYSPARK_JOB = {
                         "reference": {"project_id": '{{ config.run_config.spark.project_id }}'},
                         "placement": {"cluster_name": '{{ config.run_config.spark.cluster_name }}'},
-                        "pyspark_job": {"main_python_file_uri": '{{ config.run_config.spark.artifacts_path }}/{{ project_name }}-{{ git_info.commit_sha }}-{{ node.name }}.py'},
+                        "pyspark_job": {"main_python_file_uri": '{{ config.run_config.spark.artifacts_path }}/{{ project_name }}-{{ git_info.commit_sha }}-{{ node.name }}.py',
+                                        "properties": {
+                                            {% if mlflow_url %}
+                                            "spark.executorEnv.MLFLOW_RUN_ID": "{% raw %}{{ ti.xcom_pull(key='mlflow_run_id') }}{% endraw %}",
+                                            "spark.yarn.appMasterEnv.MLFLOW_RUN_ID": "{% raw %}{{ ti.xcom_pull(key='mlflow_run_id') }}{% endraw %}",
+                                            {% endif %}
+                                        }
+                        },
                     }
         tasks["{{ node.name | slugify }}"] = DataprocSubmitJobOperator(
             task_id="kedro-{{ node.name | slugify }}", job=PYSPARK_JOB, location='{{ config.run_config.spark.region }}', project_id='{{ config.run_config.spark.project_id }}'


### PR DESCRIPTION
Environment variables is passed as `spark.yarn.appMasterEnv.*` and `spark.executorEnv.*` property.

---
Keep in mind: 
- [x] Documentation updates
- [x] [Changelog](CHANGELOG.md) updates 
