### PR TITLE
Take DAG status from the final task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+-   Take DAG status from the final task
 -   Fix finding pyspark DataFrames
 -   `MLFLOW_RUN_ID` passed as environment variable to dataproc oriented pipelines
 

--- a/kedro_airflow_k8s/airflow_dag_template.j2
+++ b/kedro_airflow_k8s/airflow_dag_template.j2
@@ -5,6 +5,7 @@ from airflow.kubernetes.secret import Secret
 from airflow.utils.dates import days_ago
 from airflow.utils.task_group import TaskGroup
 from airflow.sensors.external_task import ExternalTaskSensor
+from airflow.operators.dummy import DummyOperator
 from datetime import timedelta
 from datetime import datetime
 
@@ -121,6 +122,8 @@ with DAG(
     {%- if custom_spark_factory %}
     {{ custom_spark_factory.imports_statement | indent() }}
     {%- endif %}
+
+    final = DummyOperator(task_id='final', dag=dag)
 
     tasks = {}
     with TaskGroup("kedro", prefix_group_id=False) as kedro_group:
@@ -296,8 +299,9 @@ with DAG(
     {% endif %}
 
     {% if not config.run_config.volume.disabled %}
-    kedro_group >> delete_pipeline_storage
+    kedro_group >> delete_pipeline_storage >> final
     {% endif %}
+    kedro_group >> final
 
 if __name__ == "__main__":
     dag.cli()


### PR DESCRIPTION
Without it, despite kedro_group failing, the DAG was marked as success,
because delete_pipeline_storage was always executed last (it has trigger=all_done).

https://stackoverflow.com/questions/51728441/dag-marked-as-success-if-one-task-fails-because-of-trigger-rule-all-done

---
Keep in mind: 
- [X] Documentation updates
- [X] [Changelog](CHANGELOG.md) updates 
