### PR TITLE
Handle `KEDRO_ENV` environment variable (#105)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 -   Support spark projects on K8S
+-   FIX: handle `KEDRO_ENV` environment variable
 
 ## [0.7.3] - 2021-11-16
 

--- a/README.md
+++ b/README.md
@@ -4,12 +4,12 @@
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0) 
 [![SemVer](https://img.shields.io/badge/semver-2.0.0-green)](https://semver.org/)
 [![PyPI version](https://badge.fury.io/py/kedro-airflow-k8s.svg)](https://pypi.org/project/kedro-airflow-k8s/)
-[![Downloads](https://pepy.tech/badge/kedro-airflow-k8s)](https://pepy.tech/project/kedro-airflow-k8s) 
+[![Downloads](https://img.shields.io/pypi/dm/kedro-airflow-k8s)](https://img.shields.io/pypi/dm/kedro-airflow-k8s) 
 
 [![Maintainability](https://api.codeclimate.com/v1/badges/f2ef65a9be497267c738/maintainability)](https://codeclimate.com/github/getindata/kedro-airflow-k8s/maintainability)
 [![Test Coverage](https://api.codeclimate.com/v1/badges/f2ef65a9be497267c738/test_coverage)](https://codeclimate.com/github/getindata/kedro-airflow-k8s/test_coverage)
 [![Documentation Status](https://readthedocs.org/projects/kedro-airflow-k8s/badge/?version=latest)](https://kedro-airflow-k8s.readthedocs.io/en/latest/?badge=latest)
-[![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Fgetindata%2Fkedro-airflow-k8s.svg?type=shield)](https://app.fossa.com/projects/git%2Bgithub.com%2Fgetindata%2Fkedro-airflow-k8s?ref=badge_shield)
+
 ## About
 
 The main purpose of this plugin is to enable running kedro pipeline with Airflow on Kubernetes Cluster. In difference to 

--- a/kedro_airflow_k8s/cli.py
+++ b/kedro_airflow_k8s/cli.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import webbrowser
 from pathlib import Path
 from typing import Dict, List, Optional
@@ -27,7 +28,12 @@ def commands():
     context_settings=dict(help_option_names=["-h", "--help"]),
 )
 @click.option(
-    "-e", "--env", "env", type=str, default="local", help="Environment to use."
+    "-e",
+    "--env",
+    "env",
+    type=str,
+    default=lambda: os.environ.get("KEDRO_ENV", "local"),
+    help="Environment to use.",
 )
 @click.option(
     "-p",


### PR DESCRIPTION
Handle `KEDRO_ENV` environment variable similarly as described here https://kedro.readthedocs.io/en/latest/04_kedro_project_setup/02_configuration.html: if you specify both the `KEDRO_ENV` and CLI `--env` arguments, the CLI argument takes precedence.

Resolves `#105`

---
Keep in mind: 
- [x] Documentation updates
- [x] [Changelog](CHANGELOG.md) updates 
