### PR TITLE
Replaced hardcoded '/opt' in project_path in spark job with PROJECT_HOME env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 -   Support spark projects on K8S
+-   FIX: Removed hardcoded project path from spark job
 
 ## [0.7.3] - 2021-11-16
 

--- a/kedro_airflow_k8s/airflow_spark_task_template.j2
+++ b/kedro_airflow_k8s/airflow_spark_task_template.j2
@@ -6,7 +6,7 @@ from kedro.framework.startup import _get_project_metadata
 from kedro.runner import ThreadRunner
 
 startup_error = None
-project_path = "/opt/{{ project_name }}"
+project_path = os.getenv("PROJECT_HOME", "/opt/{{ project_name }}")
 
 def init_kedro(path, env: str = None, extra_params: Dict[str, Any] = None):
     """Line magic which reloads all Kedro default variables."""


### PR DESCRIPTION
Replaced hardcoded '/opt' in project_path in spark job with PROJECT_HOME environment variable which is already set in cluster init script.

Resolves #128

---
Keep in mind: 
- [ ] Documentation updates
- [x] [Changelog](CHANGELOG.md) updates 
