### PR TITLE
Ability to create ungrouped Spark pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 - Submit_operator supports `node` and `pipeline` parameters
 - Pass `node` and `pipeline` parameters to submit_operator in `airflow_dag_template.j2` jinja template
+- Extra option to skip grouping Spark nodes
 
 ## [0.8.0] - 2022-03-23
 

--- a/kedro_airflow_k8s/config.py
+++ b/kedro_airflow_k8s/config.py
@@ -93,6 +93,10 @@ run_config:
     # Apache Airflow variables to be exposed for the parameters
     variables_params: [env]
 
+    # Spark nodes are grouped by default to benefit from lazy execution.
+    # If you want to disable this behaviour, set the following value to False.
+    group_spark_nodes: True
+
     # Optional resources specification
     #resources:
         # Default configuration used by all nodes that do not declare the
@@ -549,6 +553,10 @@ class RunConfig(Config):
     def kubernetes_pod_templates(self):
         cfg = self._get_or_default("kubernetes_pod_templates", {})
         return KubernetesPodTemplates(cfg)
+
+    @property
+    def group_spark_nodes(self):
+        return self._get_or_default("group_spark_nodes", False)
 
     def _get_prefix(self):
         return "run_config."

--- a/kedro_airflow_k8s/context_helper.py
+++ b/kedro_airflow_k8s/context_helper.py
@@ -43,7 +43,12 @@ class ContextHelper(object):
 
     @property
     def pipeline_grouped(self):
-        return TaskGroupFactory().create(self.pipeline, self.context.catalog)
+        if self.config.run_config.group_spark_nodes:
+            return TaskGroupFactory().create(
+                self.pipeline, self.context.catalog
+            )
+        else:
+            return TaskGroupFactory().create_ungrouped(self.pipeline)
 
     @property
     def pipeline_name(self):

--- a/kedro_airflow_k8s/task_group.py
+++ b/kedro_airflow_k8s/task_group.py
@@ -320,3 +320,17 @@ class TaskGroupFactory:
 
         logging.info(f"Found pyspark groups: {pyspark_groups}")
         return list(default_groups.union(pyspark_groups))
+
+    def create_ungrouped(self, pipeline: Pipeline) -> List[TaskGroup]:
+        nodes_child_deps = TaskGroupFactory._get_nodes_child_deps(pipeline)
+
+        default_groups = TaskGroupFactory._create_default_groups(
+            pipeline.nodes, []
+        )
+
+        for any_group in default_groups:
+            TaskGroupFactory._set_children_dependencies(
+                any_group, default_groups, nodes_child_deps
+            )
+
+        return list(default_groups)

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md") as f:
 
 # Runtime Requirements.
 INSTALL_REQUIRES = [
-    "kedro>=0.16,<=0.18",
+    "kedro>=0.16, <0.18",
     "click<8.0",
     "semver~=2.10",
     "python-slugify>=4.0.1",
@@ -25,9 +25,10 @@ EXTRA_REQUIRE = {
         "apache-airflow-providers-cncf-kubernetes==1.1.0",
         "apache-airflow-providers-apache-spark==2.0.1",
         "mlflow-skinny==1.19.0",
+        "numpy<1.24",  # mlflow 1.19 is incompatible with numpy >= 1.24
         "sqlalchemy==1.3.23",
         "responses>=0.13.0",
-        "kedro[spark.SparkDataSet]>=0.16,<=0.18",
+        "kedro[spark.SparkDataSet]>=0.16, <0.18",
         "WTForms<3.0.0",
         "Markdown==3.3.4",
         "protobuf==3.20.3",
@@ -42,7 +43,7 @@ EXTRA_REQUIRE = {
     ],
     "aws": ["s3fs>=0.6.1"],
     "mlflow": ["kedro-mlflow==0.4.1"],
-    "spark": ["kedro[spark.SparkDataSet]>=0.16,<=0.18"],
+    "spark": ["kedro[spark.SparkDataSet]>=0.16, <0.18"],
 }
 
 setup(


### PR DESCRIPTION
Provides an extra option to skip grouping Spark nodes

---
Keep in mind: 
- [ ] Documentation updates
- [x] [Changelog](CHANGELOG.md) updates 
